### PR TITLE
IS-909: Add print block height option for sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,21 @@
 
 ```bash
 (venv) $ icondbtools sync --help
-usage: icondbtools sync [-h] --db DB [-s START] [-c COUNT]
+usage: icondbtools sync [-h] --db DB [-s START] [--end END] [-c COUNT]
                         [-o BUILTIN_SCORE_OWNER] [--stop-on-error]
-                        [--no-commit] [--write-precommit-data]
+                        [--no-commit] [--write-precommit-data] [--no-fee]
+                        [--no-audit] [--deployer-whitelist]
+                        [--score-package-validator] [--channel CHANNEL]
+                        [--backup-period BACKUP_PERIOD]
+                        [--is-config IS_CONFIG]
+                        [--print-block-height PRINT_BLOCK_HEIGHT]
 
 optional arguments:
   -h, --help            show this help message and exit
   --db DB
   -s START, --start START
                         start height to sync
+  --end END             end height to sync, inclusive
   -c COUNT, --count COUNT
                         The number of blocks to sync
   -o BUILTIN_SCORE_OWNER, --owner BUILTIN_SCORE_OWNER
@@ -50,6 +56,14 @@ optional arguments:
   --deployer-whitelist  Enable deployer whitelist
   --score-package-validator
                         Enable score package validator
+  --channel CHANNEL     channel name used as a key of commit_state in block
+                        data
+  --backup-period BACKUP_PERIOD
+                        Backup statedb every this period blocks
+  --is-config IS_CONFIG
+                        iconservice_config.json filepath
+  --print-block-height PRINT_BLOCK_HEIGHT
+                        Print every this block height
 
 (venv) $ icondbtools sync --db ./db_13.125.135.114:7100_icon_dex --stop-on-error
 ```

--- a/icondbtools/command/command_sync.py
+++ b/icondbtools/command/command_sync.py
@@ -61,6 +61,7 @@ class CommandSync(Command):
             default='icon_dex', help='channel name used as a key of commit_state in block data')
         parser_sync.add_argument('--backup-period', type=int, default=0, help="Backup statedb every this period blocks")
         parser_sync.add_argument('--is-config', type=str, default="", help="iconservice_config.json filepath")
+        parser_sync.add_argument('--print-block-height', type=int, default=1, help="Print every this block height")
         parser_sync.set_defaults(func=self.run)
 
     def run(self, args):
@@ -79,6 +80,7 @@ class CommandSync(Command):
         channel: str = args.channel
         backup_period: int = args.backup_period
         iconservice_config_path: str = args.is_config
+        print_block_height: int = args.print_block_height
 
         reader = StateDatabaseReader()
 
@@ -108,6 +110,9 @@ class CommandSync(Command):
               f'deployerWhitelist: {deployer_whitelist}\n'
               f'scorePackageValidator: {score_package_validator}\n')
 
+        if print_block_height < 1:
+            raise ValueError(f'print block height should be more than 0')
+
         syncer = IconServiceSyncer()
         try:
             syncer.open(
@@ -121,6 +126,7 @@ class CommandSync(Command):
                 db_path, channel, start_height=start, count=count,
                 stop_on_error=stop_on_error, no_commit=no_commit,
                 write_precommit_data=write_precommit_data,
-                backup_period=backup_period)
+                backup_period=backup_period,
+                print_block_height=print_block_height)
         finally:
             syncer.close()

--- a/icondbtools/libs/icon_service_syncer.py
+++ b/icondbtools/libs/icon_service_syncer.py
@@ -23,10 +23,6 @@ from typing import TYPE_CHECKING, Optional, List, Tuple, Dict
 
 from iconcommons.icon_config import IconConfig
 from iconcommons.logger import Logger
-
-from icondbtools.utils.convert_type import object_to_str
-from icondbtools.utils.transaction import create_transaction_requests
-from icondbtools.word_detector import WordDetector
 from iconservice.base.address import Address
 from iconservice.base.block import Block
 from iconservice.database.batch import TransactionBatchValue
@@ -34,6 +30,10 @@ from iconservice.icon_config import default_icon_config
 from iconservice.icon_constant import Revision
 from iconservice.icon_service_engine import IconServiceEngine
 from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreContext
+
+from icondbtools.utils.convert_type import object_to_str
+from icondbtools.utils.transaction import create_transaction_requests
+from icondbtools.word_detector import WordDetector
 from .block_database_reader import BlockDatabaseReader
 from .loopchain_block import LoopchainBlock
 from .vote import Vote
@@ -241,7 +241,7 @@ class IconServiceSyncer(object):
             commit_state: bytes = self._block_reader.get_commit_state(block_dict, channel, b'')
 
             # "commit_state" is the field name of state_root_hash in loopchain block
-            if height % print_block_height == 0:
+            if (height - start_height) % print_block_height == 0:
                 print(f'{height} | {commit_state.hex()[:6]} | {state_root_hash.hex()[:6]} | {len(tx_requests)}')
 
             if write_precommit_data:

--- a/icondbtools/libs/icon_service_syncer.py
+++ b/icondbtools/libs/icon_service_syncer.py
@@ -174,7 +174,8 @@ class IconServiceSyncer(object):
              stop_on_error: bool = True,
              no_commit: bool = False,
              backup_period: int = 0,
-             write_precommit_data: bool = False) -> int:
+             write_precommit_data: bool = False,
+             print_block_height: int = 1) -> int:
         """Begin to synchronize IconServiceEngine with blocks from loopchain db
 
         :param db_path: loopchain db path
@@ -185,6 +186,7 @@ class IconServiceSyncer(object):
         :param no_commit: Do not commit
         :param backup_period: state backup period in block
         :param write_precommit_data:
+        :param print_block_height: print every this block height
         :return: 0(success), otherwise(error)
         """
         Logger.debug(tag=self._TAG, msg="_run() start")
@@ -239,7 +241,8 @@ class IconServiceSyncer(object):
             commit_state: bytes = self._block_reader.get_commit_state(block_dict, channel, b'')
 
             # "commit_state" is the field name of state_root_hash in loopchain block
-            print(f'{height} | {commit_state.hex()[:6]} | {state_root_hash.hex()[:6]} | {len(tx_requests)}')
+            if height % print_block_height == 0:
+                print(f'{height} | {commit_state.hex()[:6]} | {state_root_hash.hex()[:6]} | {len(tx_requests)}')
 
             if write_precommit_data:
                 self._print_precommit_data(block)


### PR DESCRIPTION
- Prints block height, commit state, state root hash, and length of TX requests every input block height