### PR TITLE
Fixed reps_hash key when copy

### DIFF
--- a/icondbtools/command/command_copy.py
+++ b/icondbtools/command/command_copy.py
@@ -86,8 +86,9 @@ class CommandCopy(Command):
                 if block_dict['version'] != "0.1a":
                     # Copy reps_data
                     reps_hash: str = block_dict.get("repsHash", "0x")[2:]
-                    reps_data = block_reader.get_reps(bytes.fromhex(reps_hash))
-                    wb.put(PREPS_KEY_PREFIX + reps_hash.encode(UTF8), reps_data)
+                    reps_hash_key: bytes = bytes.fromhex(reps_hash)
+                    reps_data = block_reader.get_reps(reps_hash_key)
+                    wb.put(PREPS_KEY_PREFIX + reps_hash_key, reps_data)
 
                     # Copy next_reps_data
                     next_reps_hash = block_dict.get("nextRepsHash")


### PR DESCRIPTION
loopchain db use  not string encoded bytes but real `bytes` as `reps_hash` key.
